### PR TITLE
Add YaCy Search Engine Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Awesome DeFi apps you can deploy on Akash
 
 ### Search Engine
 
-- [YaCy][yacy]
+- [YaCy](yacy)
 
 ### Mining
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Awesome DeFi apps you can deploy on Akash
 
 - [Whoogle Search](whoogle-search)
 
+### Search Engine
+
+- [YaCy][yacy]
+
 ### Mining
 
 - [xmrig](monero)

--- a/yacy/README.md
+++ b/yacy/README.md
@@ -1,0 +1,13 @@
+YaCy Search Engine Software
+===========================
+
+YaCy is a distributed Web Search Engine, based on a peer-to-peer network.
+
+Homepage: [YaCy.net](https://yacy.net)
+
+Using This SDL
+--------------
+
+- HTTP port 8090 must be exposed globally as port 80 (or YaCy will refuse to crawl without any error). Exposing HTTPS port 8443 is not required.
+- Enabling persistent storage feature in SDL is highly recommended. Some settings in YaCy requires a server restart and it will reset all of your data.
+- Default username and password to access administrative features is `admin` and `yacy`.

--- a/yacy/deploy.yaml
+++ b/yacy/deploy.yaml
@@ -29,13 +29,18 @@ profiles:
               persistent: true
               class: beta3
   placement:
-    westcoast:
+    akash:
+      attributes:
+        host: akash
+      signedBy:
+        anyOf:
+          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
       pricing:
         yacy-profile:
           denom: uakt
-          amount: 1000
+          amount: 100000
 deployment:
   yacy:
-    westcoast:
+    akash:
       profile: yacy-profile
       count: 1

--- a/yacy/deploy.yaml
+++ b/yacy/deploy.yaml
@@ -1,0 +1,41 @@
+---
+version: "2.0"
+
+services:
+  yacy:
+    image: yacy/yacy_search_server:latest
+    expose:
+      - port: 8090
+        as: 80
+        to:
+          - global: true
+    params:
+      storage:
+        data:
+          mount: /opt/yacy_search_server/DATA
+profiles:
+  compute:
+    yacy-profile:
+      resources:
+        cpu:
+          units: 8.0
+        memory:
+          size: 16Gi
+        storage:
+          - size: 1Gi
+          - name: data
+            size: 50Gi
+            attributes:
+              persistent: true
+              class: beta3
+  placement:
+    westcoast:
+      pricing:
+        yacy-profile:
+          denom: uakt
+          amount: 1000
+deployment:
+  yacy:
+    westcoast:
+      profile: yacy-profile
+      count: 1


### PR DESCRIPTION
See: [https://yacy.net](https://yacy.net)

Note: Port 8090 must be exposed as 80 or otherwise YaCy will refuse to crawl.