### PR TITLE
fix: WordPress has a capital P

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,4 +1,4 @@
-# Wordpress
+# WordPress
 
 WordPress is a free and open source blogging tool and a content management system (CMS) based on PHP and MySQL.  This SDL includes Redis for mem cache and MariaDB (MySQL fork).
 


### PR DESCRIPTION
the p in WordPress should be capital! 

https://twitter.com/octalmage/status/1642333485728686084