### PR TITLE
fix(stable-diffusion-ui): Make grep case-insensitive.

### DIFF
--- a/stable-diffusion-ui/entrypoint.sh
+++ b/stable-diffusion-ui/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Get the download URL of the latest release from the Stable Diffusion UI GitHub repository
 url=$(curl -s https://api.github.com/repos/cmdr2/stable-diffusion-ui/releases/latest \
-| grep "browser_download_url.*linux.zip" \
+| grep -i "browser_download_url.*linux.zip" \
 | cut -d : -f 2,3 \
 | tr -d '"' \
 | xargs)
@@ -14,6 +14,6 @@ wget $url
 version=$(echo $url | sed 's/.*\([0-9]\.[0-9]\.[0-9]\).*/\1/')
 
 echo "Stable Diffusion UI version $version downloaded successfully."
-unzip stable-diffusion-ui-linux.zip
+unzip Easy-Diffusion-Linux.zip
 echo "Starting Stable Diffusion UI."
-cd stable-diffusion-ui ; ./start.sh
+cd easy-diffusion ; ./start.sh


### PR DESCRIPTION
There's been a few changes that cause this SDL to fail, with the below modifications I was able to get it up and running! 

stable-diffusion-ui was renamed to Easy-Diffusion.