### PR TITLE
A.I. - Follow StableDiffusion URL redirection

### DIFF
--- a/stable-diffusion-ui/entrypoint.sh
+++ b/stable-diffusion-ui/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get the download URL of the latest release from the Stable Diffusion UI GitHub repository
-url=$(curl -s https://api.github.com/repos/cmdr2/stable-diffusion-ui/releases/latest \
+url=$(curl -Ls https://api.github.com/repos/cmdr2/stable-diffusion-ui/releases/latest \
 | grep -i "browser_download_url.*linux.zip" \
 | cut -d : -f 2,3 \
 | tr -d '"' \


### PR DESCRIPTION
The current call to `curl` fails with 
```
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/528152092/releases/latest",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```
which impacts the rest of the deployment script.

This PR fixes this issue by passing the `-L` option to `curl` which allows `curl` to follow the redirection.

Edit: One will need to re-create the Docker image and modify the deployment file to reflect the change.