### PR TITLE
Add SQL server startup env variables

### DIFF
--- a/MySQL/deploy.yaml
+++ b/MySQL/deploy.yaml
@@ -14,6 +14,7 @@ services:
           - global: true
     env:
       - "MYSQL_ROOT_PASSWORD=my-secret-password"
+      - "MYSQL_DATABASE=mydb"
 
 profiles:
   compute:

--- a/MySQL/deploy.yaml
+++ b/MySQL/deploy.yaml
@@ -12,6 +12,9 @@ services:
         as: 80
         to:
           - global: true
+    env:
+      - "MYSQL_ROOT_PASSWORD=my-secret-password"
+
 profiles:
   compute:
     mysql:


### PR DESCRIPTION
Required in newer versions of MySQL.

Tested on DuckDNS with a standard SQL client