### PR TITLE
Update deploy.yaml

### DIFF
--- a/uptime-kuma/deploy.yaml
+++ b/uptime-kuma/deploy.yaml
@@ -2,7 +2,8 @@
 version: '2.0'
 services:
   uptime-kuma-persistent:
-    image: 'louislam/uptime-kuma:1.23.1'
+    image: louislam/uptime-kuma:1.23.1
+
     expose:
       - port: 3001
         as: 80

--- a/uptime-kuma/deploy.yaml
+++ b/uptime-kuma/deploy.yaml
@@ -1,37 +1,46 @@
 ---
-version: "2.0"
-
+version: '2.0'
 services:
-  uptime:
-    image: louislam/uptime-kuma:1.18.0
+  uptime-kuma-persistent:
+    image: 'louislam/uptime-kuma:latest'
     expose:
       - port: 3001
         as: 80
         to:
           - global: true
+    params:
+      storage:
+        data:
+          mount: /app/data
+          readOnly: false
 profiles:
   compute:
-    uptime:
+    uptime-kuma-persistent:
       resources:
         cpu:
           units: 0.5
         memory:
-          size: 128Mi
+          size: 512Mb
         storage:
-          - size: 512Mi
+          - size: 128Mb
+          - name: data
+            size: 1GB
+            attributes:
+              persistent: true
+              class: beta1
   placement:
     akash:
-      signedBy:
-        anyOf:
-          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
-          - "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4"        
       pricing:
-        uptime: 
+        uptime-kuma-persistent:
           denom: uakt
           amount: 10000
-
+      signedBy:
+        anyOf:
+          - akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63
+          - akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4
 deployment:
-  uptime:
+  uptime-kuma-persistent:
     akash:
-      profile: uptime
+      profile: uptime-kuma-persistent
       count: 1
+

--- a/uptime-kuma/deploy.yaml
+++ b/uptime-kuma/deploy.yaml
@@ -2,7 +2,7 @@
 version: '2.0'
 services:
   uptime-kuma-persistent:
-    image: 'louislam/uptime-kuma:latest'
+    image: 'louislam/uptime-kuma:1.23.1'
     expose:
       - port: 3001
         as: 80


### PR DESCRIPTION
change it to persistent storage, updated to latest image, thats about it.

This is done for a better first time user experience, so they won't loose their configurations after a provider reboot.

Have tested that it works and is actually persistent across provider reboots, have not run extensive testing tho.
seems fine and i doubled storage space just to be on the safe side, 512MB seemed a bit low, incase somebody was to add a lot of stuff to it...

the original storage was reduced from 512MB to 128MB, since it is mandatory and thus cannot be completely removed.