### PR TITLE
Fix: disable xformers, add comfyui reference

### DIFF
--- a/comfyui/README.md
+++ b/comfyui/README.md
@@ -9,3 +9,19 @@ This ui will let you design and execute advanced stable diffusion pipelines usin
 Env variables MODELURLS, VAEURLS and UPSCALEURLS can be set to automatically download models on deployment start. Just add a string with download urls separated by ","
 
 COMMANDLINE_ARGS can be found [here](https://github.com/comfyanonymous/ComfyUI/blob/9bfec2bdbf0b0d778087a9b32f79e57e2d15b913/comfy/cli_args.py#L36)
+
+Loading Checkpoints, VAEs and Upscalers
+
+Before you can run inference, you'll need to load checkpoint files, VAEs and any upscalers. You can use wget to copy them into specific folders (examples below):
+
+Load Checkpoints:
+wget https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors
+wget https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0/resolve/main/sd_xl_refiner_1.0.safetensors
+
+Load VAE
+wget https://huggingface.co/madebyollin/sdxl-vae-fp16-fix/resolve/main/sdxl_vae.safetensors
+
+Load Upscalers
+wget https://huggingface.co/madebyollin/sdxl-vae-fp16-fix/resolve/main/sdxl_vae.safetensors
+wget https://huggingface.co/uwg/upscaler/resolve/main/ESRGAN/4x-UltraSharp.pth
+

--- a/comfyui/deploy.yaml
+++ b/comfyui/deploy.yaml
@@ -12,7 +12,7 @@ services:
       - "VAEURLS="
       - "MODELURLS="
       - "UPSCALEURLS="
-      - "COMMANDLINE_ARGS=--listen --port 8080 --gpu-only"
+      - "COMMANDLINE_ARGS=--listen --port 8080 --gpu-only --disable-xformers"
 profiles:
   compute:
     app:


### PR DESCRIPTION
- Added cmd arg to disable xformers (doesn't work with it enabled for some reason - still need to root cause)
- Added reference in README on how to load checkpoints, VAEs and upscalers
