### PR TITLE
Add Nitropage

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Also, follow [@akashnet\_](https://twitter.com/akashnet_) to stay in the loop wi
 - [Confluence](confluence)
 - [Drupal](drupal)
 - [Wiki.js](wikijs)
+- [Nitropage](nitropage)
 
 ### Built with Cosmos-SDK
 
@@ -334,4 +335,3 @@ Awesome DeFi apps you can deploy on Akash
 ### Web Frameworks
 
 - [NextJS](nextjs)
-- [Nitropage](nitropage)

--- a/README.md
+++ b/README.md
@@ -334,3 +334,4 @@ Awesome DeFi apps you can deploy on Akash
 ### Web Frameworks
 
 - [NextJS](nextjs)
+- [Nitropage](nitropage)

--- a/nitropage/README.md
+++ b/nitropage/README.md
@@ -1,0 +1,31 @@
+# Nitropage
+
+Visit [https://nitropage.com/](https://nitropage.com/) for more information about `Nitropage`.  
+  
+This repository contains an example deployment for the `Nitropage Starter` project.  
+It uses a SQLite database and is intended for demo purpose only.  
+  
+This Akash template can be deployed as is using the pre-built Docker image or re-built and customized using [this repository](https://github.com/0x1d/nitropage-akash).
+
+## Getting Started
+
+- deploy this template with your favorite deployment tool for Akash (e.g. [Cloudmos](https://deploy.cloudmos.io/))
+- when the deployment is up and running, visit http://your-deployment-url/admin to create an admin account
+- after first login, you need to create a Nitropage project by setting the project name and your Akash deployment domain (without http and trailing slash)
+- now you're ready to create your website
+
+## About
+
+From [Nitropage](https://git.lufrai.org/nitropage/nitropage)
+
+Nitropage is a completely free, open-source, self-hostable alternative to premium, visual drag-and-drop website builders such as [Squarespace](https://www.squarespace.com/) and [Wix](https://www.wix.com/). Write your own building blocks with [SolidJS](https://www.solidjs.com/) and enjoy the power of HMR!
+
+## Features
+
+- [x] Publishing Workflow with Page Revisions
+- [x] Element Setting Presets
+- [x] Multiple Websites on a single instance
+- [x] Custom Page Elements with [SolidJS](https://www.solidjs.com/)
+- [x] Powerful Developer Architecture with [Vite](https://vitejs.dev/)
+- [x] Automatic sitemap.xml and Atom-feed handling 
+- [ ] And [many more to come](https://nitropage.com/#roadmap)

--- a/nitropage/deploy.yaml
+++ b/nitropage/deploy.yaml
@@ -1,0 +1,39 @@
+---
+version: "2.0"
+services:
+  nitropage:
+    image: wirelos/nitropage:0.33.0
+    expose:
+      - port: 3000
+        as: 80
+        http_options:
+          max_body_size: 104857600
+        to:
+          - global: true
+    env:
+      - DATABASE_URL=file:/var/db/dev.db
+profiles:
+  compute:
+    nitropage:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 256Mi
+        storage:
+          - size: 1Gi
+  placement:
+    dcloud:
+      signedBy:
+        anyOf:
+          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
+          - "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4"    
+      pricing:
+        nitropage:
+          denom: uakt
+          amount: 1000
+deployment:
+  nitropage:
+    dcloud:
+      profile: nitropage
+      count: 1


### PR DESCRIPTION
This change add the Nitropage-Starter project deployment. 

Nitropage is a completely free, open-source, self-hostable alternative to premium, visual drag-and-drop website builders such as Squarespace and Wix.
Visit https://nitropage.com/ for more information.