### PR TITLE
add tensorflow-jupyter-ezkl

### DIFF
--- a/tensorflow-jupyter-ezkl/README.md
+++ b/tensorflow-jupyter-ezkl/README.md
@@ -1,5 +1,5 @@
 # Jupyter Notebook with ezkl
 
-The `deploy.yaml` deploys a Jupyter environment with Python kernel and ezkl preinstalled, which is a popular toolkit for proving machine learning inferences. The deployment comes with TensorFlow and all the sample notebooks included in the ezkl repository.
+The `deploy.yaml` deploys a Jupyter environment with Python kernel and ezkl preinstalled, which is a popular toolkit for proving AI inferences. The deployment comes with TensorFlow and all the sample notebooks included in the ezkl repository.
 
-For more information, see both the [GitHub repo](https://github.com/inference-labs-inc/docker-ezkl) and [EZKL](https://github.com/zkonduit/ezkl) for more information.
+For more information, see both the [GitHub repo](https://github.com/inference-labs-inc/docker-ezkl) and [EZKL](https://github.com/zkonduit/ezkl).

--- a/tensorflow-jupyter-ezkl/README.md
+++ b/tensorflow-jupyter-ezkl/README.md
@@ -1,0 +1,5 @@
+# Jupyter Notebook with ezkl
+
+The `deploy.yaml` deploys a Jupyter environment with Python kernel and ezkl preinstalled, which is a popular toolkit for proving machine learning inferences. The deployment comes with TensorFlow and all the sample notebooks included in the ezkl repository.
+
+For more information, see both the [GitHub repo](https://github.com/inference-labs-inc/docker-ezkl) and [EZKL](https://github.com/zkonduit/ezkl) for more information.

--- a/tensorflow-jupyter-ezkl/deploy.yaml
+++ b/tensorflow-jupyter-ezkl/deploy.yaml
@@ -1,0 +1,20 @@
+---
+version: "2.0"
+services:
+  ezkl:
+    image: inferencelabs/ezkl-notebook:v1.1.1
+    expose:
+      - port: 8888
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    ezkl:
+      resources:
+        cpu:
+          units: 8
+        memory:
+          size: 16GB
+        storage:
+          - size: 10Gi


### PR DESCRIPTION
Added a prebuilt docker image with [EZKL](https://github.com/zkonduit/ezkl) and jupyter for easy deployment for proving within akash.

The base [GitHub repo](https://github.com/inference-labs-inc/docker-ezkl) with the source Dockerfile for reference