### PR TITLE
Implemented image for grok w/ weights and deployer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Also, follow [@akashnet\_](https://twitter.com/akashnet_) to stay in the loop wi
 - [Falcon-7B](Falcon-7B)
 - [FastChat](FastChat)
 - [Flan-T5 XXL](flan-t5-xxl)
+- [Grok](grok)
 - [GPT-Neo](gpt-neo)
 - [Llama-2-70B](Llama-2-70B)
 - [RedPajama-INCITE-7B-Instruct](redpajama-incite-7b-instruct)

--- a/grok/Dockerfile
+++ b/grok/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y git python3 aria2 && \
+    apt-get clean
+
+WORKDIR /app
+
+COPY entrypoint.sh .
+ENTRYPOINT ["bash", "/app/entrypoint.sh"]

--- a/grok/README.md
+++ b/grok/README.md
@@ -1,0 +1,18 @@
+# Grok-1
+
+**Please be aware of potential costs when deploying this.**
+
+This deployment sets up all dependencies for [grok-1](https://github.com/xai-org/grok-1), downloads the weights, and runs the model.
+
+Weights are ~296GB in size and take ~10h+ to download via torrent (aria2c).
+Due to DockerHub limitations in dockerfile layer size, we cannot build the weights into the image and must do this at entrypoint.sh.
+
+Model is 314B int8 params, so 314GB of mem is required to load the model.
+
+Approximately 630GB of VRAM is required to run the model, this is equivalent to ~8 H100s (80GB).
+
+# License
+
+The code and associated Grok-1 weights in this release are licensed under the
+Apache 2.0 license. The license only applies to the source files in this
+repository and the model weights of Grok-1.

--- a/grok/deploy.yaml
+++ b/grok/deploy.yaml
@@ -1,0 +1,44 @@
+---
+version: "2.0"
+
+services:
+  grok:
+    image: idiombytes/xaigrok:0.1
+    expose:
+      - port: 8080
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    grok:
+      resources:
+        cpu:
+          units: 16.0 # Ensure high clock speed and I/O capabilities
+        memory:
+          size: 512Gi # This is on the edge; consider upgrading if possible
+        storage:
+          size: 1Ti # Accommodate model, cache, and operational data
+        gpu:
+          units: 8 # Targeting 630/80VRAM ~= 8 GPUs
+          attributes:
+            vendor:
+              nvidia:
+                - model: h100
+  placement:
+    akash:
+      attributes:
+        host: akash
+      signedBy:
+        anyOf:
+          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
+          - "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4"
+      pricing:
+        grok: 
+          denom: uakt
+          amount: 10000
+deployment:
+  grok:
+    akash:
+      profile: grok
+      count: 1

--- a/grok/entrypoint.sh
+++ b/grok/entrypoint.sh
@@ -1,0 +1,10 @@
+# Download the grok-1 weights, move them to `checkpoints/ckpt-0` directory
+mkdir -p checkpoints/
+aria2c -d weights --summary-interval 5 --check-certificate=false --max-tries=99 --retry-wait=5 --always-resume=true --max-file-not-found=99 --conditional-get=true -s 8 -x 8 -k 1M -j 1 'magnet:?xt=urn:btih:5f96d43576e3d386c9ba65b883210a393b68210e&tr=https%3A%2F%2Facademictorrents.com%2Fannounce.php&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce'
+mv weights/grok-1/ckpt-0/ checkpoints/
+rm -r weights/
+
+# Clone the grok-1 repository, install reqs, and run the model
+git clone https://github.com/xai-org/grok-1 .
+pip install -r requirements.txt
+python run.py


### PR DESCRIPTION
**Please be aware of potential costs when deploying this.**

This deployment sets up all dependencies for [grok-1](https://github.com/xai-org/grok-1), downloads the weights, and runs the model.

Weights are ~296GB in size and take ~10h+ to download via torrent (aria2c).
Due to DockerHub limitations in dockerfile layer size, we cannot build the weights into the image and must do this at entrypoint.sh.

Model is 314B int8 params, so 314GB of mem is required to load the model.

Approximately 630GB of VRAM is required to run the model, this is equivalent to ~8 H100s (80GB).
