### PR TITLE
Add ubuntu bare image with ssh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .vim
 .DS_Store
+.idea

--- a/ssh-bare-images/Dockerfile.ubuntu
+++ b/ssh-bare-images/Dockerfile.ubuntu
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends -- ssh; \
+    mkdir -p -m0755 /run/sshd; \
+    mkdir -m700 ~/.ssh; \
+    touch ~/.ssh/authorized_keys; \
+    chmod 0600 ~/.ssh/authorized_keys;
+
+COPY ssh-entrypoint.sh /usr/local/bin/init.sh
+
+ENTRYPOINT ["/usr/local/bin/init.sh"]
+
+CMD ["tail", "-f", "/dev/null"]
+
+EXPOSE 22

--- a/ssh-bare-images/ssh-entrypoint.sh
+++ b/ssh-bare-images/ssh-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "$SSH_PUBKEY" | tee ~/.ssh/authorized_keys; \
+/usr/sbin/sshd
+
+exec "$@"


### PR DESCRIPTION
This task adds an ubuntu image to be used as a bare VM image with ssh access as described in akash-network/cloudmos#227

Once this is approved I'll build it, push to github registry and proceed with UI works within cloudmos. After that I plan to add other distros.