### PR TITLE
fix(image/llama): use the exact digest manifest

### DIFF
--- a/Llama-3.1/Llama-3.1-405B-Instruct-AWQ-INT4.yml
+++ b/Llama-3.1/Llama-3.1-405B-Instruct-AWQ-INT4.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   vllm:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8000
         as: 8000

--- a/Llama-3.1/Llama-3.1-405B-Instruct-FP8.yaml
+++ b/Llama-3.1/Llama-3.1-405B-Instruct-FP8.yaml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   vllm:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8000
         as: 8000

--- a/Llama-3.1/Llama-3.1-405B-Instruct.yaml
+++ b/Llama-3.1/Llama-3.1-405B-Instruct.yaml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   rayhead:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8000
         as: 8000
@@ -87,7 +87,7 @@ services:
           mount: /root/.cache # Mount the data storage to the cache directory for persistent storage of model files
           readOnly: false
   rayworker:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8078
         as: 8078
@@ -114,7 +114,7 @@ services:
           mount: /root/.cache # Mount the data storage to the cache directory for persistent storage of model files
           readOnly: false
   rayworker2:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8078
         as: 8078

--- a/Llama-3.1/Llama-3.1-8B-Instruct.yaml
+++ b/Llama-3.1/Llama-3.1-8B-Instruct.yaml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   vllm:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8000
         as: 8000

--- a/Llama-3/Llama-3-70B-Instruct.yaml
+++ b/Llama-3/Llama-3-70B-Instruct.yaml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   vllm:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8000
         as: 8000

--- a/Llama-3/Llama-3-8B-Instruct.yaml
+++ b/Llama-3/Llama-3-8B-Instruct.yaml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   vllm:
-    image: vllm/vllm-openai:v0.5.3.post1
+    image: vllm/vllm-openai:v0.5.3.post1@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62
     expose:
       - port: 8000
         as: 8000


### PR DESCRIPTION
the reason being are different issues ranging from "CUDA error: uncorrectable ECC error encountered" up to "NCCL error: unhandled system error" sort of errors with seemingly the same vllm/vllm-openai:v0.5.3.post1 image until it turned out that they pushed different versions of it behind the same image tag v0.5.3.post1

Example:

- BAD vllm/vllm-openai@sha256:f69e0acef342b7d0475086a5a99afa9e2ba2ee74c5ace91052dd3680b354ac4c (CUDA: 12.4.1)
- GOOD vllm/vllm-openai@sha256:bfb0403010061e61b692e337945fb9694baefb03b0725d62adab9cca6139ea62 (CUDA: 12.1.0)