### PR TITLE
fix(base-ssh,ssh-ubuntu): use tini for zombie reaping and signal handling (#565)

### DIFF
--- a/base-ssh/Dockerfile.centos
+++ b/base-ssh/Dockerfile.centos
@@ -13,7 +13,15 @@ RUN dnf -y update && \
 COPY ssh-entrypoint.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
-ENTRYPOINT ["/usr/local/bin/init.sh"]
+# Use tini as an init system to manage orphaned child processes, ensuring they
+# don't become zombie (defunct) processes by reaping (cleaning up) them when
+# their parent process doesn't.
+# Tini will also correctly handle signals like SIGTERM (15), allowing child
+# processes to terminate gracefully within the allotted time, rather than
+# being forcefully killed with SIGKILL after a 15-second timeout.
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/base-ssh/Dockerfile.debian
+++ b/base-ssh/Dockerfile.debian
@@ -10,7 +10,15 @@ RUN apt-get update; \
 COPY ssh-entrypoint.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
-ENTRYPOINT ["/usr/local/bin/init.sh"]
+# Use tini as an init system to manage orphaned child processes, ensuring they
+# don't become zombie (defunct) processes by reaping (cleaning up) them when
+# their parent process doesn't.
+# Tini will also correctly handle signals like SIGTERM (15), allowing child
+# processes to terminate gracefully within the allotted time, rather than
+# being forcefully killed with SIGKILL after a 15-second timeout.
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/base-ssh/Dockerfile.suse
+++ b/base-ssh/Dockerfile.suse
@@ -14,7 +14,15 @@ RUN mkdir -p /run/sshd && \
 COPY ssh-entrypoint.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
-ENTRYPOINT ["/usr/local/bin/init.sh"]
+# Use tini as an init system to manage orphaned child processes, ensuring they
+# don't become zombie (defunct) processes by reaping (cleaning up) them when
+# their parent process doesn't.
+# Tini will also correctly handle signals like SIGTERM (15), allowing child
+# processes to terminate gracefully within the allotted time, rather than
+# being forcefully killed with SIGKILL after a 15-second timeout.
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/base-ssh/Dockerfile.ubuntu
+++ b/base-ssh/Dockerfile.ubuntu
@@ -10,7 +10,15 @@ RUN apt-get update; \
 COPY ssh-entrypoint.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
-ENTRYPOINT ["/usr/local/bin/init.sh"]
+# Use tini as an init system to manage orphaned child processes, ensuring they
+# don't become zombie (defunct) processes by reaping (cleaning up) them when
+# their parent process doesn't.
+# Tini will also correctly handle signals like SIGTERM (15), allowing child
+# processes to terminate gracefully within the allotted time, rather than
+# being forcefully killed with SIGKILL after a 15-second timeout.
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/ssh-ubuntu/Dockerfile.ubuntu
+++ b/ssh-ubuntu/Dockerfile.ubuntu
@@ -10,7 +10,15 @@ RUN apt-get update; \
 COPY ssh-entrypoint.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
-ENTRYPOINT ["/usr/local/bin/init.sh"]
+# Use tini as an init system to manage orphaned child processes, ensuring they
+# don't become zombie (defunct) processes by reaping (cleaning up) them when
+# their parent process doesn't.
+# Tini will also correctly handle signals like SIGTERM (15), allowing child
+# processes to terminate gracefully within the allotted time, rather than
+# being forcefully killed with SIGKILL after a 15-second timeout.
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 


### PR DESCRIPTION
Use tini as an init system to manage orphaned child processes, ensuring they don't become zombie (defunct) processes by reaping (cleaning up) them when their parent process doesn't.

Tini will also correctly handle signals like SIGTERM (15), allowing child processes to terminate gracefully within the allotted time, rather than being forcefully killed with SIGKILL after a 15-second timeout.