### PR TITLE
radicle: update image, enable API by default and allow repo pinning

### DIFF
--- a/radicle/README.md
+++ b/radicle/README.md
@@ -14,7 +14,7 @@ Akash Network exposes your service on a random port which is then forwarded to t
 1. Find the random port assigned to your deployment
 2. Update the `RAD_EXTERNAL_ADDR` variable with the public address and port (e.g. `RAD_EXTERNAL_ADDR=provider.url:65432`).
 
-The deployment also allows you to enable HTTP server by setting `RAD_HTTP_ENABLE` to `true`.
+The deployment also allows enable radicle-httpd HTTP API server by setting `RAD_HTTP_ENABLE` to `true`. If ythe API is enabled, you can also pin repositories which will show up when you call `GET /api/v1/repos` by listing them in `RAD_PINNED_REPOS` (separated by `;`). Pinned repositories are also automatically seeded.
 
 ## Usage
 

--- a/radicle/deploy.yaml
+++ b/radicle/deploy.yaml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   node:
-    image: quay.io/vpavlin0/radicle-seed:latest
+    image: quay.io/vpavlin0/radicle-seed@sha256:c51be795e278e1c80bcb88cf5fab89858d54c7885a4764c711427334751b6289
     
     expose:
       - port: 8776
@@ -11,7 +11,7 @@ services:
         to:
           - global: true
       - port: 8080
-        as: 8080
+        as: 80
         to:
           - global: true
 
@@ -22,9 +22,10 @@ services:
     env:
       - RAD_ALIAS=
       - RAD_SEEDS=rad:zNd4qti1Jc69mCBQAdBeK3Avzy4R
+      - RAD_PINNED_REPOS=rad:zNd4qti1Jc69mCBQAdBeK3Avzy4R
       - RAD_EXTERNAL_ADDR=
       - RAD_SEEDING_POLICY=block
-      - RAD_HTTP_ENABLE=false
+      - RAD_HTTP_ENABLE=true
     
 profiles:
   compute:


### PR DESCRIPTION
This change

* uses `sha` to pin image version (to update radicle and radicle-httpd to latest versions)
* sets radicle-httpd (API server) on by default
* add new env var to pin repos (which are the default repos returned by `/api/v1/repos` call)
* use port 80 to leverage k8s ingress to get domain name automatically (e.g. http://hm3fmfap1h8nd8k1v3dvbed1lg.ingress.tekti.net/api/v1/repos)