### PR TITLE
security(base-ssh, ssh-ubuntu): use distro package manager to install tini

### DIFF
--- a/base-ssh/Dockerfile.centos
+++ b/base-ssh/Dockerfile.centos
@@ -19,9 +19,13 @@ RUN chmod +x /usr/local/bin/init.sh
 # Tini will also correctly handle signals like SIGTERM (15), allowing child
 # processes to terminate gracefully within the allotted time, rather than
 # being forcefully killed with SIGKILL after a 15-second timeout.
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
+ENV TINI_URL="https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-amd64"
+RUN curl -o /usr/bin/tini -fsSL ${TINI_URL} && \
+    curl -o /usr/bin/tini.asc -fsSL ${TINI_URL}.asc && \
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+    gpg --verify /usr/bin/tini.asc && \
+    chmod +x /usr/bin/tini
+ENTRYPOINT ["tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/base-ssh/Dockerfile.debian
+++ b/base-ssh/Dockerfile.debian
@@ -1,7 +1,7 @@
 FROM debian:11
 
 RUN apt-get update; \
-    apt-get install -y --no-install-recommends -- ssh; \
+    apt-get install -y --no-install-recommends -- tini ssh; \
     mkdir -p -m0755 /run/sshd; \
     mkdir -m700 ~/.ssh; \
     touch ~/.ssh/authorized_keys; \
@@ -16,9 +16,7 @@ RUN chmod +x /usr/local/bin/init.sh
 # Tini will also correctly handle signals like SIGTERM (15), allowing child
 # processes to terminate gracefully within the allotted time, rather than
 # being forcefully killed with SIGKILL after a 15-second timeout.
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/base-ssh/Dockerfile.suse
+++ b/base-ssh/Dockerfile.suse
@@ -1,7 +1,7 @@
 FROM opensuse/leap:15.5
 
 RUN zypper refresh && \
-    zypper install -y openssh && \
+    zypper install -y tini openssh && \
     zypper clean -a
 
 RUN mkdir -p /run/sshd && \
@@ -20,9 +20,9 @@ RUN chmod +x /usr/local/bin/init.sh
 # Tini will also correctly handle signals like SIGTERM (15), allowing child
 # processes to terminate gracefully within the allotted time, rather than
 # being forcefully killed with SIGKILL after a 15-second timeout.
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
+# openSUSE tini installs under /tini
+RUN ln -sv /tini /usr/bin/tini
+ENTRYPOINT ["tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/base-ssh/Dockerfile.ubuntu
+++ b/base-ssh/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update; \
-    apt-get install -y --no-install-recommends -- ssh; \
+    apt-get install -y --no-install-recommends -- tini ssh; \
     mkdir -p -m0755 /run/sshd; \
     mkdir -m700 ~/.ssh; \
     touch ~/.ssh/authorized_keys; \
@@ -16,9 +16,7 @@ RUN chmod +x /usr/local/bin/init.sh
 # Tini will also correctly handle signals like SIGTERM (15), allowing child
 # processes to terminate gracefully within the allotted time, rather than
 # being forcefully killed with SIGKILL after a 15-second timeout.
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 

--- a/ssh-ubuntu/Dockerfile.ubuntu
+++ b/ssh-ubuntu/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update; \
-    apt-get install -y --no-install-recommends -- ssh; \
+    apt-get install -y --no-install-recommends -- tini ssh; \
     mkdir -p -m0755 /run/sshd; \
     mkdir -m700 ~/.ssh; \
     touch ~/.ssh/authorized_keys; \
@@ -16,9 +16,7 @@ RUN chmod +x /usr/local/bin/init.sh
 # Tini will also correctly handle signals like SIGTERM (15), allowing child
 # processes to terminate gracefully within the allotted time, rather than
 # being forcefully killed with SIGKILL after a 15-second timeout.
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/init.sh"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/init.sh"]
 
 CMD ["tail", "-f", "/dev/null"]
 


### PR DESCRIPTION
Use the default distro package manager to install `tini` whenever possible. If the package manager is unavailable or does not provide `tini`, ensure the GPG signature is verified using a trusted side-channel method.

Changes:
- Updated Dockerfiles for CentOS, Debian, SUSE, and Ubuntu to install `tini` via the package manager or, if necessary, from the official release with GPG verification.
- Adjusted entry points to utilize the package-installed `tini`.