### PR TITLE
dria: update to v0.2.2

### DIFF
--- a/dria/README.md
+++ b/dria/README.md
@@ -4,8 +4,12 @@
 
 ## Setup
 
+> NOTE: Prefer providers in Europe as the network will penalize nodes in US because of latency: https://github.com/firstbatchxyz/dkn-compute-node/issues/119 
+
 Check [dkn-compute-node](https://hub.docker.com/r/firstbatch/dkn-compute-node/tags) Docker repository to see if there is a new version and update `dkn` service `image`.
 
 You need to provide an Ethereum wallet private key in `DKN_WALLET_SECRET_KEY` environment variable. The walelt address derived from this key represents your identity in Dria network.
 
 You can also modify models supported by your node in `DKN_MODELS` environment variable. Consult the [guide](https://firstbatch.notion.site/How-to-Run-a-Node-ed2bef2c8eec4dd280286f2e081e51d2) to see the options.
+
+Make sure your node follows resource recommendations in [Minimum Specs](https://github.com/firstbatchxyz/dkn-node-specs) guide.

--- a/dria/deploy.yaml
+++ b/dria/deploy.yaml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   dkn:
-    image: firstbatch/dkn-compute-node:v0.1.6
+    image: firstbatch/dkn-compute-node:v0.2.2
     expose:
     - port: 80
       as: 80
@@ -26,23 +26,18 @@ services:
     - OLLAMA_AUTO_PULL=true
     - OLLAMA_HOST=http://ollama
     - OLLAMA_PORT=11434
-    - RUST_LOG=none,dkn_compute=info
+    - RUST_LOG=none,dkn_compute=debug,ollama_workflows=info
 
     - DKN_ADMIN_PUBLIC_KEY=0208ef5e65a9c656a6f92fb2c770d5d5e2ecffe02a6aade19207f75110be6ae658
 
   ollama:
-    image: ollama/ollama@sha256:532b563c005c1d60cf959d498418e0d3b5cc1f02f6a1608ae7d0c0a8a3c8a2f5 #this is the image `latest` pointed to on 2024-08-19, update if needed
+    image: ollama/ollama@sha256:a45c1ae866f0ad115b5b2b5048cb80e02a8c49c36f60d49f449b0d6a3825cdbf #this is the image `latest` pointed to on 2024-08-19, update if needed
     expose:
       - port: 11434
         as: 11434
         to:
           - global: false
           - service: dkn
-    params:
-      storage:
-        ollamadata:
-          mount: /root/.ollama
-          readOnly: false
 profiles:
   compute:
     dkn:
@@ -60,18 +55,13 @@ profiles:
         memory:
           size: 10Gi
         storage:
-          - size: 10Gi
-          - name: ollamadata
-            size: 24Gi
-            attributes:
-              persistent: true
-              class: beta3
+          - size: 24Gi
         gpu:
           units: 1
           attributes:
             vendor:
               nvidia:
-                - model: rtx4090
+                - model: rtx3090  #or e.g. rtx3070, 8Gi
                   ram: 24Gi
                   interface: pcie
   placement:


### PR DESCRIPTION
This PR updates 

* DKN node to v0.2.2
* Llama to latest `latest` (`a45c1ae866f0ad115b5b2b5048cb80e02a8c49c36f60d49f449b0d6a3825cdbf`)
* Update resource requirements
* Add a note about potential netowrking issues with some providers (known to Dria - https://github.com/firstbatchxyz/dkn-compute-node/issues/119)