### PR TITLE
ipfs: update, add auth

### DIFF
--- a/ipfs/README.md
+++ b/ipfs/README.md
@@ -4,4 +4,10 @@ The InterPlanetary File System (IPFS) is a protocol and peer-to-peer network for
 
 
 ## Setup
-After deploying the container the web ui will be accessible at port 80. However you will need to enter the IPFS API URL there to make it work. The IPFS API runs on port 5001, but AKASH publishes a random port and then forwards it to port 5001. With the lease-status command you have to look which port is forwarded under "forwarded_ports". Then enter the following as IPFS API URL `http://host:port` (ex: http://cluster.ews1p0.mainnet.akashian.io:30328).
+After deploying the IPFS WebUI will be available at assigned provider ingress URL. For the WebUI to work, you will need to update the deployment and set this URL in `IPFS_EXTERNAL_ADDR` (without trailing slash). 
+
+The IPFS node API is secured by nginx reverse proxy with basic auth - you can modify the user and password in the deployment via nginx service environment variables.
+
+IPFS Gateway is also available on the external address - simply use `${IPFS_EXTERNAL_ADDR}/ipfs/${CID}`.
+
+> NOTE: IPFS Kubo node requires HTTPS, so make sure your provider provides HTTPS for the ingress URL (e.g. [Europlots](https://console.akash.network/providers/akash18ga02jzaq8cw52anyhzkwta5wygufgu6zsz6xc?network=mainnet))

--- a/ipfs/deploy.yaml
+++ b/ipfs/deploy.yaml
@@ -3,24 +3,84 @@ version: "2.0"
 
 services:
   ipfs:
-    image: linuxserver/ipfs:version-v2.12.4
+    image: ipfs/kubo:v0.30.0
+    expose:
+      - port: 5001
+        as: 5001
+        to:
+          - service: nginx
+      - port: 8080
+        as: 8080
+        to:
+          - service: nginx
+    env:
+      - IPFS_EXTERNAL_ADDR= #Fill in the ingress URL assigned by the provider
+      - IPFS_LOGGING=info
+    command:
+    - sh
+    - -c
+    args:
+    - >      
+      #/usr/local/bin/start_ipfs config --json Addresses.API '"/ip4/0.0.0.0/tcp/80"'
+
+      if [ -n "${IPFS_EXTERNAL_ADDR}" ]; then
+
+        /usr/local/bin/start_ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["'${IPFS_EXTERNAL_ADDR}'", "http://ipfs:5001"]'
+        
+        /usr/local/bin/start_ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "OPTIONS"]'
+
+      fi
+      
+      exec /sbin/tini -- /usr/local/bin/start_ipfs daemon --migrate=true --agent-version-suffix=docker
+  nginx:
+    image: nginx:1.27
     expose:
       - port: 80
         as: 80
         to:
           - global: true
-      - port: 4001
-        as: 4001
-        to:
-          - global: true
-      - port: 5001
-        as: 5001
-        to:
-          - global: true
-      - port: 8080
-        as: 8080
-        to:
-          - global: true
+    env:
+      - BASIC_AUTH_USER=ipfs
+      - BASIC_AUTH_PASS=secretpass
+    command:
+      - sh
+      - -c
+    args:
+      - >
+        touch /etc/nginx/.htpasswd
+
+        if [ -n "${BASIC_AUTH_PASS}" ]; then
+          apt-get update &&\
+          apt-get install -y apache2-utils &&\
+          htpasswd -c -b /etc/nginx/.htpasswd $BASIC_AUTH_USER $BASIC_AUTH_PASS
+        fi
+
+        NGINX_CONFIG='
+        server {
+            listen       80 default_server;
+
+            client_max_body_size  100M;
+            proxy_read_timeout 300;
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
+
+            location / {
+                auth_basic             "Restricted";
+                auth_basic_user_file   .htpasswd;
+                proxy_http_version    1.1;
+                proxy_pass            http://ipfs:5001/;
+            }
+
+              location /ipfs/ {
+                proxy_http_version    1.1;
+                proxy_pass            http://ipfs:8080/ipfs/;
+            }
+        }
+        '
+
+        echo ${NGINX_CONFIG} > /etc/nginx/conf.d/ipfs.conf
+
+        nginx -g "daemon off;"
 
 profiles:
   compute:
@@ -32,16 +92,23 @@ profiles:
           size: 4Gi
         storage:
           size: 1Gi
+    nginx:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 1Gi
+        storage:
+          size: 200Mi
+
+
   placement:
     akash:
-      attributes:
-        host: akash
-      signedBy:
-        anyOf:
-          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
-          - "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4"          
       pricing:
         ipfs:
+          denom: uakt
+          amount: 10000
+        nginx:
           denom: uakt
           amount: 10000
 
@@ -50,3 +117,7 @@ deployment:
     akash:
       profile: ipfs
       count: 1
+  nginx:
+      akash:
+        profile: nginx
+        count: 1


### PR DESCRIPTION
I noticed the IPFS node is extremely outdated - and does not actually work. This PR updates to lates IPFS Kubo version + adds basic auth for webui and API to actually make it useful and usable.

* Udpate to `ipfs/kubo:v0.30.0`
* Add script to fix CSRF issues
* Add `nginx` service
* Add basic auth for IPFS UI and API (configurable via env vars)

ISSUES:

* Publishing to IPNS fails with gateway timeout
* Uploading larger files fails with `Payload too large` error

I added nginx config to fix these, but it does not seem to affect, would appreciate help with fixing these:)