### PR TITLE
Update Dria deploy.yaml

### DIFF
--- a/dria/deploy.yaml
+++ b/dria/deploy.yaml
@@ -3,7 +3,8 @@ version: "2.0"
 
 services:
   dkn:
-    image: firstbatch/dkn-compute-node:v0.3.5
+    # see images at: https://hub.docker.com/r/firstbatch/dkn-compute-node/tags
+    image: firstbatch/dkn-compute-node:v0.4.0
     expose:
       - port: 80
         as: 80


### PR DESCRIPTION
Dria Knowledge Network has made a minor version update for its next phase, the overall structure has changed greatly and v0.3.x will no longer work with the latest infrastructure.

This update fixes a major connectivity issue, and it allowed us to go from ~3K nodes to ~6.4K (at the time of writing https://dria.co/edge-ai).

Updating this image will help us include Akash nodes as well 🙏🏻 