### PR TITLE
fix: correct description of mempool/electrs as electrs fork, not Esplora

### DIFF
--- a/bitcoin-knots-mempool-ui/README.md
+++ b/bitcoin-knots-mempool-ui/README.md
@@ -109,7 +109,7 @@ This setup enables a fully integrated block explorer UI, REST API, and WebSocket
 
 ### ⚡ Why Use `mempool/electrs`?
 
-`mempool/electrs` is Blockstream's Esplora fork used for address lookups.
+`mempool/electrs` is Blockstream's electrs fork used for address lookups.
 
 When using **bitcoind alone as the backend**, the Mempool UI does **not support address lookups** and will show errors like:
 
@@ -203,7 +203,7 @@ When you deploy the full `deploy-mempool.yaml` SDL (Bitcoin Knots + Mempool stac
 
 #### ⚙️ Don't Want to Use `mempool/electrs`?
 
-If you prefer to **avoid running `mempool/electrs`** (Blockstream's Esplora fork), you can simplify your deployment with the following changes:
+If you prefer to **avoid running `mempool/electrs`** (Blockstream's electrs fork), you can simplify your deployment with the following changes:
 
 1. Set `MEMPOOL_BACKEND=none` in the `api` service.
 2. Remove or comment out the entire `mempoolelectrs` service section.

--- a/bitcoin-knots-mempool-ui/deploy-mempool.yaml
+++ b/bitcoin-knots-mempool-ui/deploy-mempool.yaml
@@ -146,7 +146,7 @@ services:
     # mysql -u root -padmin -e "SELECT table_schema AS 'Database', ROUND(SUM(data_length + index_length) / 1024 / 1024, 2) AS 'Size (MB)' FROM information_schema.tables GROUP BY table_schema ORDER BY \`Size (MB)\` DESC;"
     env:
       # Use the high-performance Electrum protocol for backend access
-      # mempool/electrs (Blockstream's Esplora fork) supports both Electrum and Esplora (REST), but Electrum is preferred
+      # mempool/electrs (Blockstream's electrs fork)
       - MEMPOOL_BACKEND=electrum
       - ELECTRUM_HOST=mempoolelectrs
       - ELECTRUM_PORT=50001


### PR DESCRIPTION
Updated README and deploy-mempool.yaml to clarify that `mempool/electrs` is a fork of electrs, not Esplora. This fixes misleading references and improves accuracy for users setting up address lookup services.