### PR TITLE
Clarify backend table labels

### DIFF
--- a/bitcoin-knots-mempool-ui/README.md
+++ b/bitcoin-knots-mempool-ui/README.md
@@ -128,11 +128,11 @@ This Electrum server enables:
 
 | Backend               | Address Lookup  | MEMPOOL\_BACKEND | Notes                                                               |
 | --------------------- | --------------- | ---------------- | ------------------------------------------------------------------- |
-| `bitcoind`            | ❌ No           | `none`           | Basic Esplora-only mode — no address history                        |
+| `bitcoind`            | ❌ No           | `none`           | Basic explorer-only mode — no address history                        |
 | `romanz/electrs`      | ⚠️  Limited      | `electrum`       | Lightweight, but struggles with high-UTXO addresses                 |
 | `cculianu/Fulcrum`    | ✅ Yes          | `electrum`       | More scalable, but not officially supported by Mempool developers   |
-| `mempool/electrs`     | ✅ Best choice  | `electrum`       | Official high-performance fork for full mempool.space compatibility |
-| `Blockstream/electrs` | ✅ Yes          | `esplora`        | Exposes REST API; required with `MEMPOOL_BACKEND=esplora`            |
+| `mempool/electrs`     | ✅ Best choice  | `electrum`       | Official high-performance fork for full mempool.space compatibility (fork of `Blockstream/electrs`) |
+| `Blockstream/esplora` | ✅ Yes          | `esplora`        | Exposes REST API; required with `MEMPOOL_BACKEND=esplora`            |
 
 We recommend `mempool/electrs` for **production deployments** or if you need **address-level transaction history**.
 


### PR DESCRIPTION
- Renamed "Blockstream/electrs" to "Blockstream/esplora" in README for clarity