### PR TITLE
bitcoind: add IP leasing support and guidance for inbound P2P connectivity

### DIFF
--- a/bitcoin-knots-mempool-ui/deploy-mempool.yaml
+++ b/bitcoin-knots-mempool-ui/deploy-mempool.yaml
@@ -1,5 +1,8 @@
 ---
 version: "2.0"
+#endpoints:
+#  bitcoind:
+#    kind: ip
 services:
   app:
     image: andrey01/bitcoin-knots:v28.1.0@sha256:f272b90297f89d9fe819548b5928367396359e3eea172d622758b90151ce12a3
@@ -17,6 +20,13 @@ services:
       - port: 8333
         to:
           - global: true
+            # "ip" - Leases a static public IP for port 8333 to allow inbound P2P connections.
+            # This ensures your Bitcoin node is reachable by peers and contributes to the Bitcoin network's decentralization and resiliency.
+            # Without this, the port would be randomly mapped (NATed) to a NodePort in the 30000–32767 range,
+            # making your node unreachable for inbound P2P unless manually advertised with workarounds.
+            # NOTE: Not all Akash Providers currently enable IP leasing, so this option is kept commented out by default.
+            # You may want to update your BITCOIN_ARGS with "-externalip=<LEASED_IP>" argument.
+            # ip: bitcoind
       # auxiliary port (e.g. for rclone serve to restore backup)
       - port: 8080
         to:

--- a/bitcoin-knots-mempool-ui/deploy.yaml
+++ b/bitcoin-knots-mempool-ui/deploy.yaml
@@ -1,5 +1,8 @@
 ---
 version: "2.0"
+#endpoints:
+#  bitcoind:
+#    kind: ip
 services:
   app:
     image: andrey01/bitcoin-knots:v28.1.0@sha256:f272b90297f89d9fe819548b5928367396359e3eea172d622758b90151ce12a3
@@ -13,6 +16,13 @@ services:
       - port: 8333
         to:
           - global: true
+            # "ip" - Leases a static public IP for port 8333 to allow inbound P2P connections.
+            # This ensures your Bitcoin node is reachable by peers and contributes to the Bitcoin network's decentralization and resiliency.
+            # Without this, the port would be randomly mapped (NATed) to a NodePort in the 30000–32767 range,
+            # making your node unreachable for inbound P2P unless manually advertised with workarounds.
+            # NOTE: Not all Akash Providers currently enable IP leasing, so this option is kept commented out by default.
+            # You may want to update your BITCOIN_ARGS with "-externalip=<LEASED_IP>" argument.
+            # ip: bitcoind
       # auxiliary port (e.g. for rclone serve to restore backup)
       - port: 8080
         to:


### PR DESCRIPTION
- Updated README.md with a new section on using leased static public IPs to enable inbound Bitcoin P2P connections (port 8333)
- Noted fallback to random NodePort behavior and JSON-RPC ingress unaffected
- Documented current Akash limitation: leased IPs are not exposed via env vars
  (see https://github.com/akash-network/support/issues/284)
- Suggested workaround using `curl ifconfig.me` to obtain public IP at runtime
- Added SDL comments in `deploy.yaml` and `deploy-mempool.yaml`:
  - Documented how to enable `ip: bitcoind` under `expose`
  - Kept IP leasing commented out by default due to limited provider support