### PR TITLE
Update Dria deploy.yaml

### DIFF
--- a/dria/deploy.yaml
+++ b/dria/deploy.yaml
@@ -4,7 +4,7 @@ version: "2.0"
 services:
   dkn:
     # see images at: https://hub.docker.com/r/firstbatch/dkn-compute-node/tags
-    image: firstbatch/dkn-compute-node:v0.4.1
+    image: firstbatch/dkn-compute-node:v0.6.1
     expose:
       - port: 80
         as: 80
@@ -14,25 +14,25 @@ services:
       # You need to provide a wallet private key here
       - DKN_WALLET_SECRET_KEY=
       # You can modify list of supported/enabled models - check the resources, might need a bump with more/different models
-      - DKN_MODELS=,llama3.1:latest
+      # see: https://docs.dria.co/#supported-models
+      # provde as comma-separated values, e.g.: model1,model2,model3
+      - DKN_MODELS=gemma3:4b
 
-      # You can provide API keys to integrate with other services
+      # You can provide API keys to integrate with other services, if you dont want to run local models
       - OPENAI_API_KEY=
       - GEMINI_API_KEY
       - OPENROUTER_API_KEY=
-
-      # These are optional (not model related) but will make you return better results
-      - SERPER_API_KEY=
-      - JINA_API_KEY=
 
       # You probably don't want to touch these
       - OLLAMA_AUTO_PULL=true
       - OLLAMA_HOST=http://ollama
       - OLLAMA_PORT=11434
-      - RUST_LOG=none,dkn_compute=debug,dkn_workflows=debug,dkn_p2p=debug,ollama_workflows=info
+
+      # let compute node know that we are in Akash
+      - DKN_EXEC_PLATFORM=akash/v0.6.1
 
   ollama:
-    image: ollama/ollama@sha256:a45c1ae866f0ad115b5b2b5048cb80e02a8c49c36f60d49f449b0d6a3825cdbf #this is the image `latest` pointed to on 2024-08-19, update if needed
+    image: ollama/ollama@sha256:2ea3b768a8f2dcd4d910f838d79702bb952089414dd578146619c0a939647ac6 # `latest` image on Jun 1, 2025 (update if needed)
     expose:
       - port: 11434
         as: 11434


### PR DESCRIPTION
We have moved to a new network verison, which requires the `major.minor` version to match with the latest one. This updates bumps those versions, along with some env updates.