### PR TITLE
Add: Axolotl AI training setup for Akash deployment

### DIFF
--- a/axolotlai/.env.example
+++ b/axolotlai/.env.example
@@ -1,0 +1,25 @@
+# Copy to .env and fill these before deploying on Akash
+JUPYTER_TOKEN=change_me_to_a_strong_random_string
+
+# Optional: Hugging Face (private models/datasets)
+HF_TOKEN=
+
+# Optional: Weights & Biases
+WANDB_API_KEY=
+WANDB_PROJECT=
+WANDB_ENTITY=
+# Set to offline to disable network tracking:
+# WANDB_MODE=offline
+
+# Optional: directories (defaults work out of the box)
+BASE_VOLUME=/workspace/data
+AXOLOTL_CONFIG_DIR=/src/config
+HF_DATASETS_CACHE=/workspace/data/huggingface-cache/datasets
+HUGGINGFACE_HUB_CACHE=/workspace/data/huggingface-cache/hub
+TRANSFORMERS_CACHE=/workspace/data/huggingface-cache/hub
+# HF_HOME=
+
+# Optional: performance tuning
+# HF_HUB_ENABLE_HF_TRANSFER=1
+# HF_HUB_ENABLE_SAFETENSORS_FAST=1
+# TORCH_CUDA_ALLOC_CONF=expandable_segments:True

--- a/axolotlai/Tranning_confid.md
+++ b/axolotlai/Tranning_confid.md
@@ -1,0 +1,301 @@
+# Axolotl Training Configuration Reference (Akash)
+
+This document lists the configuration options supported by Axolotl for LLM post-training (full fine-tune, LoRA, QLoRA, etc.) across providers. It is provider-neutral and works on Akash.
+
+Use YAML for native Axolotl runs and optionally JSON if you have an orchestration API that posts jobs.
+
+- On Akash:
+  - Place YAML configs in `AXOLOTL_CONFIG_DIR` (default: `/src/config`) and run from JupyterLab or a shell inside the container.
+  - Keep datasets/models/caches under `BASE_VOLUME` (default: `/workspace/data`). Use the persistent-data SDL to persist between redeploys.
+- Secrets:
+  - Do not hardcode secrets in YAML/JSON. Use environment variables (e.g., `HF_TOKEN`, `WANDB_API_KEY`).
+
+## Quick usage
+
+YAML (recommended for Akash )
+
+```yaml
+# examples/akash/quickstart.yaml
+base_model: "NousResearch/Llama-3.2-1B"
+load_in_4bit: true
+adapter: "lora"
+sequence_len: 2048
+
+datasets:
+  - path: "teknium/GPT4-LLM-Cleaned"
+    type: "alpaca"
+    split: "train[:1000]"
+
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.05
+lora_target_modules:
+  - q_proj
+  - v_proj
+  - k_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+gradient_checkpointing: true
+micro_batch_size: 2
+gradient_accumulation_steps: 8
+epochs: 1
+optimizer: "adamw_torch"
+learning_rate: 2e-4
+lr_scheduler: "cosine"
+warmup_ratio: 0.03
+bf16: true
+
+output_dir: "/workspace/data/outputs/quickstart"
+hub_model_id: "your-hf-username/llama-3.2-1b-quickstart"
+```
+
+JSON (only if your orchestration expects a request body)
+
+```json
+{
+  "input": {
+    "user_id": "user",
+    "model_id": "model-name",
+    "run_id": "run-id",
+    "credentials": {
+      "wandb_api_key": "",
+      "hf_token": ""
+    },
+    "args": {
+      "base_model": "NousResearch/Llama-3.2-1B"
+      // other supported options below
+    }
+  }
+}
+```
+
+Notes:
+- Prefer env vars (`HF_TOKEN`, `WANDB_API_KEY`) over `credentials` fields.
+- On Akash, dataset local paths live under `/workspace/data/...` if using the persistent volume.
+
+---
+
+## Model Configuration
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `base_model` | Path or HF ID of the base model | Required |
+| `base_model_config` | Separate config path for the base model | Same as model |
+| `revision_of_model` | Specific model revision on HF | Latest |
+| `tokenizer_config` | Path to custom tokenizer config | Optional |
+| `model_type` | Model class to load | AutoModelForCausalLM |
+| `tokenizer_type` | Tokenizer class | AutoTokenizer |
+| `hub_model_id` | HF Hub repo to push (username/repo) | Optional |
+
+### Model Family Identification (auto-detected in most cases)
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `is_falcon_derived_model` | false | Falcon-based |
+| `is_llama_derived_model` | false | LLaMA-based |
+| `is_qwen_derived_model` | false | Qwen-based |
+| `is_mistral_derived_model` | false | Mistral-based |
+
+### Model Config Overrides
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `overrides_of_model_config.rope_scaling.type` | "linear" | linear/dynamic |
+| `overrides_of_model_config.rope_scaling.factor` | 1.0 | Scaling factor |
+
+## Model Loading Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `load_in_8bit` | 8-bit quantized load | false |
+| `load_in_4bit` | 4-bit quantized load | false |
+| `bf16` | Use bfloat16 | false |
+| `fp16` | Use float16 | false |
+| `tf32` | Use TF32 | false |
+
+## Memory and Device
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `gpu_memory_limit` | "20GiB" | Cap per-GPU memory |
+| `lora_on_cpu` | false | Place LoRA on CPU |
+| `device_map` | "auto" | Device strategy |
+| `max_memory` | null | Per-device max memory map |
+
+## Training Hyperparameters
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `gradient_accumulation_steps` | 1 | Accumulation steps |
+| `micro_batch_size` | 2 | Per-GPU batch size |
+| `eval_batch_size` | null | Eval batch size |
+| `num_epochs` | 4 | Training epochs |
+| `warmup_steps` | 100 | Warmup steps |
+| `warmup_ratio` | 0.05 | Warmup ratio |
+| `learning_rate` | 0.00003 | LR |
+| `lr_quadratic_warmup` | false | Quadratic warmup |
+| `logging_steps` | null | Log freq |
+| `eval_steps` | null | Eval freq |
+| `evals_per_epoch` | null | Evals per epoch |
+| `save_strategy` | "epoch" | Save strategy |
+| `save_steps` | null | Save freq |
+| `saves_per_epoch` | null | Saves per epoch |
+| `save_total_limit` | null | Max checkpoints |
+| `max_steps` | null | Max steps |
+
+## Dataset Configuration
+
+YAML example:
+```yaml
+datasets:
+  - path: vicgalle/alpaca-gpt4
+    type: alpaca
+    ds_type: json
+    data_files: path/to/data
+    split: train
+```
+
+Notes for Akash:
+- For local data on a persistent volume, place it under `/workspace/data/...` and reference with an absolute path.
+
+## Chat Template
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `chat_template` | "tokenizer_default" | Template type |
+| `chat_template_jinja` | null | Custom Jinja template |
+| `default_system_message` | "You are a helpful assistant." | System message |
+
+## Dataset Processing
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `dataset_prepared_path` | "data/last_run_prepared" | Prepared output |
+| `push_dataset_to_hub` | "" | Push to HF Hub |
+| `dataset_processes` | 4 | Preprocess workers |
+| `dataset_keep_in_memory` | false | Keep in RAM |
+| `shuffle_merged_datasets` | true | Shuffle merged |
+| `shuffle_before_merging_datasets` | false | Shuffle per-dataset |
+| `dataset_exact_deduplication` | true | Deduplicate |
+
+## LoRA/QLoRA
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `adapter` | "lora" | lora/qlora |
+| `lora_model_dir` | "" | Pretrained LoRA dir |
+| `lora_r` | 8 | Rank |
+| `lora_alpha` | 16 | Alpha |
+| `lora_dropout` | 0.05 | Dropout |
+| `lora_target_modules` | ["q_proj","v_proj"] | Target modules |
+| `lora_target_linear` | false | All linear |
+| `peft_layers_to_transform` | [] | Layers |
+| `lora_modules_to_save` | [] | Extra modules |
+| `lora_fan_in_fan_out` | false | Fan in/out |
+
+## Optimization
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `train_on_inputs` | false | Train on prompts |
+| `group_by_length` | false | Bucket by length |
+| `gradient_checkpointing` | false | Save VRAM |
+| `early_stopping_patience` | 3 | Early stop |
+
+## LR Scheduling
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `lr_scheduler` | "cosine" | Scheduler |
+| `lr_scheduler_kwargs` | {} | Params |
+| `cosine_min_lr_ratio` | null | Min LR ratio |
+| `cosine_constant_lr_ratio` | null | Const LR |
+| `lr_div_factor` | null | Div factor |
+
+## Optimizer
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `optimizer` | "adamw_hf" | Choice |
+| `optim_args` | {} | Args |
+| `optim_target_modules` | [] | Targets |
+| `weight_decay` | null | Weight decay |
+| `adam_beta1` | null | Beta1 |
+| `adam_beta2` | null | Beta2 |
+| `adam_epsilon` | null | Epsilon |
+| `max_grad_norm` | null | Clip |
+
+Supported optimizers include:
+- adamw_hf, adamw_torch, adamw_torch_fused, adamw_torch_xla, adamw_apex_fused
+- adafactor, adamw_anyprecision, adamw_bnb_8bit
+- lion_8bit, lion_32bit, sgd, adagrad
+
+## Attention Implementations
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `flash_optimum` | false | Better TFMs |
+| `xformers_attention` | false | xFormers |
+| `flash_attention` | false | Flash-Attn |
+| `flash_attn_cross_entropy` | false | Cross-entropy |
+| `flash_attn_rms_norm` | false | RMS norm |
+| `flash_attn_fuse_mlp` | false | Fuse MLP |
+| `sdp_attention` | false | Scaled dot product |
+| `s2_attention` | false | Shifted sparse |
+
+## Tokenizer Modifications
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `special_tokens` | - | Token additions |
+| `tokens` | [] | Extra tokens |
+
+## Distributed Training
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `fsdp` | null | FSDP config |
+| `fsdp_config` | null | FSDP opts |
+| `deepspeed` | null | Deepspeed path |
+| `ddp_timeout` | null | DDP timeout |
+| `ddp_bucket_cap_mb` | null | Bucket cap |
+| `ddp_broadcast_buffers` | null | Broadcast buffers |
+
+## Advanced Features
+
+### Weights & Biases
+
+- `wandb_project`, `wandb_entity`, `wandb_watch`, `wandb_name`, `wandb_run_id`
+- Prefer env vars: `WANDB_API_KEY`, `WANDB_PROJECT`, `WANDB_ENTITY`, `WANDB_MODE`
+
+### Performance
+
+- `sample_packing`, `eval_sample_packing`
+- `torch_compile`
+- `flash_attention`, `xformers_attention`
+
+## Environment variables (cross-provider)
+
+Required:
+- `JUPYTER_TOKEN` (for JupyterLab on Akash/RunPod images)
+
+Optional:
+- Hugging Face: `HF_TOKEN`, `HF_HOME`
+- W&B: `WANDB_API_KEY`, `WANDB_PROJECT`, `WANDB_ENTITY`, `WANDB_MODE`
+- Paths: `BASE_VOLUME` (default `/workspace/data`), `AXOLOTL_CONFIG_DIR` (default `/src/config`)
+- Caches: `HF_DATASETS_CACHE`, `HUGGINGFACE_HUB_CACHE`, `TRANSFORMERS_CACHE`
+- Jupyter: `JUPYTER_ENABLE_LAB`
+- Performance: `HF_HUB_ENABLE_HF_TRANSFER`, `HF_HUB_ENABLE_SAFETENSORS_FAST`, `TORCH_CUDA_ALLOC_CONF`
+
+## Notes
+
+- Use `load_in_8bit` or `load_in_4bit` to reduce memory.
+- `flash_attention: true` can accelerate training on supported GPUs; otherwise keep it false.
+- Use `gradient_checkpointing: true` to reduce VRAM usage.
+- Tune `micro_batch_size` and `gradient_accumulation_steps` based on GPU memory.
+- If Flash-Attn issues occur on Akash, restart or redeploy your lease (or disable flash attention). Ensure your image and drivers support it.
+
+For more details, see the Axolotl docs.

--- a/axolotlai/config.json
+++ b/axolotlai/config.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "../config.schema.json",
+    "ssh": false,
+    "logoUrl": "https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/887513285d98132142bf5db2a74eb5e0928787f1/image/axolotl_logo_digital_black.svg"
+}

--- a/axolotlai/deploy-persistent.yaml
+++ b/axolotlai/deploy-persistent.yaml
@@ -1,0 +1,64 @@
+version: "2.0"
+services:
+  axolotl-trainer:
+    image: axolotlai/axolotl-cloud:main-latest
+    expose:
+      - port: 8888
+        as: 80
+        to:
+          - global: true
+    env:
+      - HF_DATASETS_CACHE=/workspace/data/huggingface-cache/datasets
+      - HUGGINGFACE_HUB_CACHE=/workspace/data/huggingface-cache/hub
+      - TRANSFORMERS_CACHE=/workspace/data/huggingface-cache/hub
+      - WANDB_API_KEY=${WANDB_API_KEY}
+      - HF_TOKEN=${HF_TOKEN}
+      - BASE_VOLUME=/workspace/data
+      - AXOLOTL_CONFIG_DIR=/src/config
+      - JUPYTER_ENABLE_LAB=yes
+      - JUPYTER_TOKEN=mysecretpass #change this to a strong password
+    params:
+      storage:
+        data:
+          mount: /workspace/data
+          readOnly: false
+        axolotl-config:
+          mount: /src/config
+          readOnly: false
+
+profiles:
+  compute:
+    axolotl-trainer:
+      resources:
+        cpu:
+          units: 24
+        memory:
+          size: 251Gi
+        storage:
+          - name: data
+            size: 500Gi
+            attributes:
+              persistent: true
+              class: beta3    #change to your preferable storage type
+          - name: axolotl-config
+            size: 50Gi
+            attributes:
+              persistent: true
+              class: beta3      #change to your preferable storage type 
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              nvidia:
+  placement:
+    gpu-providers:
+      pricing:
+        axolotl-trainer:
+          denom: ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1
+          amount: 2000000 # adjust as needed
+
+deployment:
+  axolotl-trainer:
+    gpu-providers:
+      profile: axolotl-trainer
+      count: 1

--- a/axolotlai/deploy.yaml
+++ b/axolotlai/deploy.yaml
@@ -1,0 +1,59 @@
+---
+version: "2.0"
+services:
+  axolotl-trainer:
+    image: axolotlai/axolotl-cloud:main-latest #change to your preferred image tag 
+    expose:
+      - port: 8888
+        as: 80
+        to:
+          - global: true
+    env:
+      - HF_DATASETS_CACHE=/workspace/data/huggingface-cache/datasets
+      - HUGGINGFACE_HUB_CACHE=/workspace/data/huggingface-cache/hub
+      - TRANSFORMERS_CACHE=/workspace/data/huggingface-cache/hub
+      - WANDB_API_KEY=${WANDB_API_KEY}
+      - HF_TOKEN=${HF_TOKEN}
+      - BASE_VOLUME=/workspace/data
+      - AXOLOTL_CONFIG_DIR=/src/config
+      - JUPYTER_ENABLE_LAB=yes
+      - JUPYTER_TOKEN=mysecretpass  # change this to a strong password
+    params:
+      storage:
+        axolotl-config:
+          mount: /src/config
+          readOnly: false
+profiles:
+  compute:
+    axolotl-trainer:
+      resources:
+        cpu:
+          units: 24
+        memory:
+          size: 251Gi
+        storage:
+          - size: 550Gi
+            attributes:
+              persistent: true
+              class: beta3          #change to your preferable storage type
+          - name: axolotl-config
+            size: 2Gi
+            attributes:
+              persistent: true
+              class: beta3        #change to your preferable storage type 
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              nvidia:
+  placement:
+    gpu-providers:
+      pricing:
+        axolotl-trainer:
+          denom: uakt
+          amount: 2000000
+deployment:
+  axolotl-trainer:
+    gpu-providers:
+      profile: axolotl-trainer
+      count: 1

--- a/axolotlai/llama-3.2-1b-lora-4bit.yaml
+++ b/axolotlai/llama-3.2-1b-lora-4bit.yaml
@@ -1,0 +1,27 @@
+base_model: "NousResearch/Llama-3.2-1B"
+load_in_4bit: true
+adapter: "lora"
+sequence_len: 2048
+
+datasets:
+  - path: "teknium/GPT4-LLM-Cleaned"
+    type: alpaca
+    split: "train[:1000]"
+
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.05
+lora_target_modules: ["q_proj","v_proj","k_proj","o_proj","gate_proj","up_proj","down_proj"]
+
+gradient_checkpointing: true
+micro_batch_size: 2
+gradient_accumulation_steps: 8
+epochs: 1
+optimizer: "adamw_torch"
+learning_rate: 2e-4
+lr_scheduler: "cosine"
+warmup_ratio: 0.03
+bf16: true
+
+output_dir: "/workspace/data/outputs/quickstart"
+hub_model_id: "your-hf-username/llama-3.2-1b-quickstart"

--- a/axolotlai/readme.md
+++ b/axolotlai/readme.md
@@ -1,0 +1,81 @@
+# Axolotl AI - LLM Fine-tuning on Akash
+
+<p align="center">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/887513285d98132142bf5db2a74eb5e0928787f1/image/axolotl_logo_digital_white.svg">
+        <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/887513285d98132142bf5db2a74eb5e0928787f1/image/axolotl_logo_digital_black.svg">
+        <img alt="Axolotl" src="https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/887513285d98132142bf5db2a74eb5e0928787f1/image/axolotl_logo_digital_black.svg" width="400" height="104" style="max-width: 100%;">
+    </picture>
+</p>
+
+## ✨ Overview
+
+Axolotl is a free and open-source tool designed to streamline post-training and fine-tuning for the latest large language models (LLMs).
+
+Features:
+
+- **Multiple Model Support**: Train various models like GPT-OSS, LLaMA, Mistral, Mixtral, Pythia, and many more models available on the Hugging Face Hub.
+- **Multimodal Training**: Fine-tune vision-language models (VLMs) including LLaMA-Vision, Qwen2-VL, Pixtral, LLaVA, SmolVLM2, and audio models like Voxtral with image, video, and audio support.
+- **Training Methods**: Full fine-tuning, LoRA, QLoRA, GPTQ, QAT, Preference Tuning (DPO, IPO, KTO, ORPO), RL (GRPO), and Reward Modelling (RM) / Process Reward Modelling (PRM).
+- **Easy Configuration**: Re-use a single YAML configuration file across the full fine-tuning pipeline: dataset preprocessing, training, evaluation, quantization, and inference.
+- **Performance Optimizations**: [Multipacking](https://docs.axolotl.ai/docs/multipack.html), [Flash Attention](https://github.com/Dao-AILab/flash-attention), [Xformers](https://github.com/facebookresearch/xformers), [Flex Attention](https://pytorch.org/blog/flexattention/), [Liger Kernel](https://github.com/linkedin/Liger-Kernel), [Cut Cross Entropy](https://github.com/apple/ml-cross-entropy/tree/main), [Sequence Parallelism (SP)](https://docs.axolotl.ai/docs/sequence_parallelism.html), [LoRA optimizations](https://docs.axolotl.ai/docs/lora_optims.html), [Multi-GPU training (FSDP1, FSDP2, DeepSpeed)](https://docs.axolotl.ai/docs/multi-gpu.html), [Multi-node training (Torchrun, Ray)](https://docs.axolotl.ai/docs/multi-node.html), and many more!
+- **Flexible Dataset Handling**: Load from local, HuggingFace, and cloud (S3, Azure, GCP, OCI) datasets.
+- **Cloud Ready**: We ship [Docker images](https://hub.docker.com/u/axolotlai) and also [PyPI packages](https://pypi.org/project/axolotl/) for use on cloud platforms and local hardware.
+
+- **Extensive Documentation**: Comprehensive [docs](https://docs.axolotl.ai/) and [examples](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples) are available to help you get started.
+
+## Run on Akash Network
+
+Akash provides first-class support to deploy Axolotl on the Akash decentralized GPU network.
+
+### Other Configuration Files
+
+- **[.env.example](.env.example)**: Template for environment variables needed for deployment
+- **[llama-3.2-1b-lora-4bit.yaml](llama-3.2-1b-lora-4bit.yaml)**: Example training configuration for fine-tuning Llama-3.2-1B with LoRA and 4-bit quantization
+- **[Tranning_confid.md](Tranning_confid.md)**: Comprehensive training configuration reference guide
+
+- **[deploy.yaml](deploy.yaml)**: Basic deployment configuration with ephemeral data storage and persistent configs. Use for quick starts, testing, or when dataset re-download is acceptable.
+- **[deploy-persistent.yaml](deploy-persistent.yaml)**: Persistent deployment configuration with both data and configs stored persistently. Use for long-running training jobs where dataset persistence is required.
+
+### Environment Variables
+
+**Required**:
+- `JUPYTER_TOKEN`: Strong password to log into JupyterLab
+
+**Optional (commonly used)**:
+- `HF_TOKEN`: Hugging Face token (for private models/datasets)
+- `WANDB_API_KEY`: Weights & Biases API key (for experiment tracking)
+- `WANDB_PROJECT`: W&B project name (default: wandb auto)
+- `WANDB_ENTITY`: W&B entity (org/user)
+- `WANDB_MODE`: Set to "offline" to disable network (optional)
+
+### Directory Structure
+
+- `BASE_VOLUME`: Base path for data (default: `/workspace/data`)
+- `AXOLOTL_CONFIG_DIR`: Path to Axolotl YAML configs (default: `/src/config`)
+- `HF_DATASETS_CACHE`: Hugging Face datasets cache (default: `/workspace/data/huggingface-cache/datasets`)
+- `HUGGINGFACE_HUB_CACHE`: HF model/hub cache (default: `/workspace/data/huggingface-cache/hub`)
+- `TRANSFORMERS_CACHE`: Transformers cache (default: `/workspace/data/huggingface-cache/hub`)
+- `HF_HOME`: Alternate HF home directory (optional, usually not needed)
+
+### Jupyter Configuration
+
+- `JUPYTER_ENABLE_LAB`: yes/no (default: yes)
+- `JUPYTER_TOKEN`: Strong password for JupyterLab auth (required)
+
+### Performance Tuning
+
+- `HF_HUB_ENABLE_HF_TRANSFER`: "1" to enable hf_transfer for faster downloads
+- `HF_HUB_ENABLE_SAFETENSORS_FAST`: "1" to enable faster safetensors
+- `TORCH_CUDA_ALLOC_CONF`: e.g., "expandable_segments:True" (optional tuning)
+
+## Resource Configuration
+
+Both deployment configurations provide substantial computational resources:
+
+- **CPU**: 24 units
+- **Memory**: 251Gi
+- **GPU**: 1x NVIDIA GPU
+- **Storage**: Ample storage (550Gi in basic, 500Gi + 50Gi in persistent)
+
+You can modify these resources based on your requirements. For detailed information about Akash network capabilities and resource specifications, refer to the [official Akash documentation](https://akash.network/docs/).


### PR DESCRIPTION

**Description**
This PR introduces an initial setup for running Axolotl-based LLM fine-tuning on the Akash decentralized GPU network. It provides a ready-to-use template that simplifies deploying, configuring, and running fine-tuning jobs directly on Akash.

**Key Additions**

* `readme.md`: Usage guide and overview for fine-tuning Axolotl on Akash
* `.env.example`: Environment variable template (HF, W\&B, caches, Jupyter token)
* `Tranning_confid.md`: Comprehensive configuration reference for Axolotl training options
* `llama-3.2-1b-lora-4bit.yaml`: Example LoRA fine-tuning configuration for Llama-3.2-1B
* `deploy.yaml`: Ephemeral data storage deployment manifest
* `deploy-persistent.yaml`: Persistent storage deployment manifest for long-running training
* `config.json`: Base config schema and metadata

**Highlights**

* Supports Hugging Face and Weights & Biases integrations
* Includes JupyterLab interface for interactive development
* Preconfigured caches, volume mounts, and persistent data handling
* Tuned compute profile for GPU-based training on Akash

**Notes**

* This is a foundational setup intended as a starting point for further fine-tuning workflows.
* Resource sizes, pricing, and secrets should be customized before deployment.

