### PR TITLE
docs: update contributing guidelines for template submissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Awesome Akash
+
+Thank you for your interest in making Awesome Akash even better! We welcome contributions of templates, resources, documentation, and other improvements that help the Akash community.
+
+***
+
+## 📦 How to Contribute a New Template/Resource
+
+1. **Create a New Folder:**
+   - Name your folder after your template/resource using lowercase, hyphen-separated naming (e.g., `next.js`).
+   - Place it in the root directory.
+
+2. **Required Files:**
+   - `deploy.yaml` — Main deployment SDL.
+   - `README.md` — Include instructions for setup, usage, and details about your template/resource.
+   - *(Optional)* `config.json` — Custom configuration (e.g., logo). Must follow the schema in `config.schema.json`. See [DeepSeek-R1/config.json](DeepSeek-R1/config.json) for an example.
+
+3. **Update Table of Contents:**
+   - Add your template/resource in the appropriate category section in the Table of Contents of the main `README.md`, maintaining alphabetical order within the category.
+   - Use the format: `[Display Name](#folder-name)` where "folder-name" matches your actual folder name.
+   - Current categories include:
+     - Official
+     - AI - CPU
+     - AI - GPU
+     - Blogging
+     - Built with Cosmos-SDK
+     - Chat
+     - Machine Learning
+     - CI/CD, DevOps
+     - Data Visualization
+     - Databases and Administration
+     - DeFi
+     - Benchmarking
+     - Blockchain
+     - Business
+     - Games
+     - Game Servers
+     - Hosting
+     - Media
+     - Search Engines
+     - Mining - CPU
+     - Mining - GPU
+     - Mining Pools
+     - Peer-to-peer File Sharing
+     - Project Management
+     - Social
+     - Decentralized Storage
+     - Tools
+     - Network
+     - Databases
+     - Video Conferencing
+     - Wallet
+     - Web Frameworks
+   - Note: The console API has a 5-minute cache, so changes may take up to 5 minutes to appear.
+
+4. **Open a Pull Request:**
+   - Title your PR as: `Add <YourTemplateName> to <Category>`
+   - Briefly describe your template/resource in the PR body.
+   - Confirm that your addition does not break the folder structure or existing files.
+
+***
+
+## 🛠️ General Contribution Tips
+
+- **Follow formatting standards:** Keep descriptions concise and links accurate.
+- **Test everything:** Ensure your resource works as described.
+- **Proofread your submissions:** Typos and broken links lower quality.
+- **Alphabetical order:** Add resources in alphabetical order within sections.
+- **No duplicates:** Check your resource isn’t already listed.
+
+***
+
+## 📝 Other Ways to Contribute
+
+- Improve documentation, tutorials, and example deployments.
+- Suggest or add new categories and organizational enhancements.
+- Report issues or broken links via [GitHub Issues](https://github.com/akash-network/awesome-akash/issues).
+- Propose infrastructure or project-wide improvements.
+
+***
+
+## 👥 Community & Support
+
+- Join our [Discord](https://discord.com/invite/akash-network) for help and discussion.
+- Feel free to open issues for suggestions, questions, or bug reports.
+
+***
+
+**Thank you for helping build the Akash community and making cloud deployment accessible for all!**

--- a/README.md
+++ b/README.md
@@ -7,14 +7,25 @@ Instructions on how to deploy the SDL files in this repository can be found [her
 Join our [Discord](https://discord.akash.network) if you have questions or concerns. Our team is always eager to hear from you.
 Also, follow [@akashnet\_](https://twitter.com/akashnet_) to stay in the loop with updates and announcements.
 
-## How to add a template to the console api <!-- omit in toc -->
+## Contributing
 
-1. Create a new folder in the root directory with the name of the template.
-2. Add the `deploy.yaml` file to the folder.
-3. Add the `README.md` file to the folder.
-4. (Optional) There's a `config.json` file that you can add to the template folder to add a custom config for the template, like a logo url. It follows the same schema as the [config.schema.json](config.schema.json) file. (ex. [DeepSeek config](DeepSeek-R1/config.json)).
-5. Add the name of the template with the name of the template that will be displayed in the console api and name of the template folder under the [Table of Contents](#table-of-contents) section in the appropriate category. (ex. `[DeepSeek-R1](#DeepSeek-R1)`)
-6. Done! There's a 5 minutes cache time for the console api to update.
+See our [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on adding new templates and resources.
+
+To add a new template/resource:
+
+1. **Create a New Folder:**
+   - Name your folder using lowercase, hyphen-separated naming (e.g., `my-template`).
+   - Place it in the root directory.
+
+2. **Required Files:**
+   - `deploy.yaml` — Main deployment SDL.
+   - `README.md` — Include instructions for setup, usage, and details about your template/resource.
+   - *(Optional)* `config.json` — Custom configuration (e.g., logo). Must follow the schema in `config.schema.json`. See [DeepSeek-R1/config.json](DeepSeek-R1/config.json) for an example.
+
+3. **Update Table of Contents:**
+   - Add your template/resource in the appropriate category section in the Table of Contents below, maintaining alphabetical order within the category.
+   - Use the format: `[Display Name](#folder-name)` where "folder-name" matches your actual folder name.
+   - Note: The console API has a 5-minute cache, so changes may take up to 5 minutes to appear.
 
 ## Table of Contents <!-- omit in toc -->
 


### PR DESCRIPTION
Rewrote the README section on adding templates to improve clarity and structure. Replaced outdated instructions with a link to CONTRIBUTING.md and added clear, step-by-step guidance for folder naming, required files, and TOC updates. Emphasized alphabetical ordering and proper formatting for consistency.